### PR TITLE
Add gitconfig local symlink example

### DIFF
--- a/git/gitconfig.local.symlink.example
+++ b/git/gitconfig.local.symlink.example
@@ -1,0 +1,5 @@
+[user]
+        name = AUTHORNAME
+        email = AUTHOREMAIL
+[credential]
+        helper = GIT_CREDENTIAL_HELPER


### PR DESCRIPTION
This PR adds gitconfig.local.symlink example.