### PR TITLE
Add setting to wipe all dock icons from macos

### DIFF
--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -278,7 +278,7 @@ defaults write com.apple.dock show-process-indicators -bool true
 # Wipe all (default) app icons from the Dock
 # This is only really useful when setting up a new Mac, or if you don’t use
 # the Dock to launch apps.
-#defaults write com.apple.dock persistent-apps -array
+defaults write com.apple.dock persistent-apps -array
 
 # Show only open applications in the Dock
 #defaults write com.apple.dock static-only -bool true


### PR DESCRIPTION
This PR updates macos defaults by adding a setting that wipes all dock icons.