### PR TITLE
Add macos option to display battery percentage

### DIFF
--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -43,6 +43,9 @@ defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
 # Set menu-bar icons.
 defaults write com.apple.systemuiserver menuExtras -array "/System/Library/CoreServices/Menu Extras/Clock.menu" "/System/Library/CoreServices/Menu Extras/AirPort.menu" "/System/Library/CoreServices/Menu Extras/Eject.menu" "/System/Library/CoreServices/Menu Extras/Volume.menu" "/System/Library/CoreServices/Menu Extras/Bluetooth.menu" "/System/Library/CoreServices/Menu Extras/TextInput.menu" "/System/Library/CoreServices/Menu Extras/Displays.menu"
 
+# Display battery percentage.
+defaults write com.apple.menuextra.battery ShowPercent YES
+
 # Disable auto-correct
 # defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 


### PR DESCRIPTION
This PR adds to the macos default configuration the option to display battery percentage