### PR TITLE
Fix missing cask versions tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 cask_args appdir: '/Applications'
 
 tap 'homebrew/bundle'
+tap 'homebrew/cask-versions'
 
 brew 'ack'
 brew 'awscli'


### PR DESCRIPTION
This PR fixes brewfile that was installing a dependency that it's only available through homebrew/cask-versions, which means that a tap was needed to make.