### PR TITLE
Update macos dock minimize windows option

### DIFF
--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -269,8 +269,8 @@ defaults write com.apple.dock tilesize -int 36
 # Change minimize/maximize window effect
 defaults write com.apple.dock mineffect -string "scale"
 
-# Minimize windows into their application’s icon
-defaults write com.apple.dock minimize-to-application -bool true
+# Don't minimize windows into their application’s icon
+defaults write com.apple.dock minimize-to-application -bool false
 
 # Enable spring loading for all Dock items
 defaults write com.apple.dock enable-spring-load-actions-on-all-items -bool true


### PR DESCRIPTION
This PR updates macos options to don't' minimize windows into their application’s icon.