### PR TITLE
Update atom disable packages config

### DIFF
--- a/atom/atom.symlink/config.cson
+++ b/atom/atom.symlink/config.cson
@@ -1,5 +1,9 @@
 "*":
   core:
+    disabledPackages: [
+      "metrics"
+      "exception-reporting"
+    ]
     telemetryConsent: "no"
   editor:
     invisibles: {}


### PR DESCRIPTION
This PR disable the following atom packages:
- metrics
- exception-reporting 