### PR TITLE
Add quick-look plugins

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,7 @@ brew 'youtube-dl'
 cask '1password'
 cask 'aerial'
 cask 'atom'
+cask 'betterzip' # https://macitbetter.com/downloads/
 cask 'docker'
 cask 'firefox'
 cask 'font-hack-nerd-font'
@@ -37,11 +38,19 @@ cask 'google-chrome-beta'
 cask 'iterm2'
 cask 'postico'
 cask 'postman'
+cask 'qlcolorcode' # https://github.com/anthonygelibert/QLColorCode
+cask 'qlmarkdown' # https://github.com/toland/qlmarkdown
+cask 'qlstephen' # https://github.com/whomwah/qlstephen
+cask 'qlvideo' # https://github.com/Marginal/QLVideo
+cask 'quicklook-json' # http://www.sagtau.com/quicklookjson.html
+cask 'quicklookase' # https://github.com/rsodre/QuickLookASE
 cask 'sequel-pro'
 cask 'slack'
 cask 'spotify'
+cask 'suspicious-package' # https://www.mothersruin.com/software/SuspiciousPackage/
 cask 'transmission'
-cask 'tunnelblick'
 cask 'tunnelbear'
+cask 'tunnelblick'
 cask 'vlc'
+cask 'webpquicklook' # https://github.com/dchest/webp-quicklook
 cask 'zoomus'


### PR DESCRIPTION
This PR adds the following quick-look plugins:
- [betterzip](https://macitbetter.com/downloads/)
- [qlcolorcode](https://github.com/anthonygelibert/QLColorCode)
- [qlmarkdown](https://github.com/toland/qlmarkdown)
- [qlstephen](https://github.com/whomwah/qlstephen)
- [qlvideo](https://github.com/Marginal/QLVideo)
- [quicklook-json](http://www.sagtau.com/quicklookjson.html)
- [quicklookase](https://github.com/rsodre/QuickLookASE)
- [suspicious-package](https://www.mothersruin.com/software/SuspiciousPackage)
- [webpquicklook](https://github.com/dchest/webp-quicklook)

Source idea: https://github.com/sindresorhus/quick-look-plugins 