### PR TITLE
Add iterm2 install script

### DIFF
--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -1,0 +1,4 @@
+
+# Install the custom themes for iTerm.
+open $ZSH"iterm2/nuno.itermcolors"
+open $ZSH/"iterm2/nuno-blue.itermcolors"

--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -542,10 +542,6 @@ defaults write com.apple.Terminal ShowLineMarks -int 0
 # Don’t display the annoying prompt when quitting iTerm
 defaults write com.googlecode.iterm2 PromptOnQuit -bool false
 
-# Install the custom themes for iTerm
-open "iterm2/nuno.itermcolors"
-open "iterm2/nuno-blue.itermcolors"
-
 # Load settings from dotfiles dir.
 defaults write com.googlecode.iterm2 PrefsCustomFolder -string "~/.dotfiles/iterm2/"
 


### PR DESCRIPTION
This PR adds iterm2 `install.sh` script and moves color scheme installation from `macos/set-defaults.sh` into the new `iterm2/install..sh` script