### PR TITLE
Add visual studio code

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -51,6 +51,7 @@ cask 'suspicious-package' # https://www.mothersruin.com/software/SuspiciousPacka
 cask 'transmission'
 cask 'tunnelbear'
 cask 'tunnelblick'
+cask 'visual-studio-code'
 cask 'vlc'
 cask 'webpquicklook' # https://github.com/dchest/webp-quicklook
 cask 'zoomus'

--- a/bin/vscode-package-backup
+++ b/bin/vscode-package-backup
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Usage: vscode-package-backup
+#
+# Saves a list of your currently installed vscode packages to
+# ~/.dotfiles/vscode/packages.txt suitable for install
+# via code --install-extension
+
+set -e
+
+code --list-extensions > ~/.dotfiles/vscode/packages.txt

--- a/bin/vscode-package-install
+++ b/bin/vscode-package-install
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Usage: vscode-package-install
+#
+# Installs the vscode extensions listed in your packages.txt file
+# located at ~/.dotfiles/vscode/packages.txt
+#
+# You can generate a new list based on currently installed
+# packages via vscode-package-backup
+
+set -e
+
+while read in; do code --install-extension "$in"; done < ~/.dotfiles/vscode/packages.txt

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,0 +1,3 @@
+User/globalStorage
+User/workspaceStorage
+

--- a/vscode/User/settings.json
+++ b/vscode/User/settings.json
@@ -1,0 +1,8 @@
+{
+    "editor.tabSize": 2,
+    "workbench.startupEditor": "newUntitledFile",
+    "workbench.iconTheme": "material-icon-theme",
+    "workbench.colorTheme": "Material Theme",
+    "editor.fontLigatures": true,
+    "window.zoomLevel": 1,
+}

--- a/vscode/install.sh
+++ b/vscode/install.sh
@@ -1,0 +1,2 @@
+rm -rf ~/Library/Application\ Support/Code/User
+ln -s ~/.dotfiles/vscode/User ~/Library/Application\ Support/Code/User

--- a/vscode/packages.txt
+++ b/vscode/packages.txt
@@ -1,0 +1,5 @@
+dbaeumer.vscode-eslint
+Equinusocio.vsc-material-theme
+esbenp.prettier-vscode
+PeterJausovec.vscode-docker
+PKief.material-icon-theme


### PR DESCRIPTION
This PR adds visual studio code to the list of installed applications.

It also includes...
- **Extensions**
  - Docker
  - ESLint extension
  - Material Theme and Material Icon Theme
  - Prettier 
- **Extension management scripts**
  - Backup extensions (bin/vscode-package-backup)
  - Install extensions (bin/vscode-package-install)
- **Personal Settings** 
