### PR TITLE
Fix projects folder env

### DIFF
--- a/go/path.zsh
+++ b/go/path.zsh
@@ -1,2 +1,2 @@
-export GOPATH=$PROJECTS/go
+export GOPATH=~/Projects/go
 export PATH="$GOPATH/bin:$PATH"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,7 +28,7 @@ fail () {
 }
 
 setup_projects_dir () {
-  mkdir -p $PROJECTS
+  mkdir -p ~/Projects
 }
 
 setup_gitconfig () {


### PR DESCRIPTION
This PR fixes the usage of `$PROJECTS` in some cases such as GOPATH and to setup the projects folder. 