### PR TITLE
Update macos hotcorners settings

### DIFF
--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -349,14 +349,15 @@ sudo ln -sf "/Applications/Xcode.app/Contents/Developer/Applications/Simulator (
 # 10: Put display to sleep
 # 11: Launchpad
 # 12: Notification Center
+# 13: Lock Screen
 # Top left screen corner → Mission Control
 defaults write com.apple.dock wvous-tl-corner -int 2
 defaults write com.apple.dock wvous-tl-modifier -int 0
 # Top right screen corner → Desktop
 defaults write com.apple.dock wvous-tr-corner -int 4
 defaults write com.apple.dock wvous-tr-modifier -int 0
-# Bottom left screen corner → Start screen saver
-defaults write com.apple.dock wvous-br-corner -int 5
+# Bottom left screen corner → Lock screen
+defaults write com.apple.dock wvous-br-corner -int 13
 defaults write com.apple.dock wvous-br-modifier -int 0
 
 ###############################################################################


### PR DESCRIPTION
This PR updates the macos hotcorners settings by setting the right bottom corner to lock the screen instead of starting screen saver.