### PR TITLE
Add CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2020.10
+    working_directory: ~/.dotfiles
+    steps:
+      - checkout
+      - run:
+          name: "Install dotfiles"
+          command: |
+            cd ~/.dotfiles
+            ./bin/dot

--- a/bin/dot
+++ b/bin/dot
@@ -86,14 +86,19 @@ setup_workspace_dir () {
 setup_gitconfig () {
   info 'Setting up gitconfig...'
 
-  if ! [ -f $DOTFILES/git/gitconfig.local.symlink ]; then
+  if ! [ -f $DOTFILES/git/gitconfig.local.symlinke ]; then
     git_credential='cache'
     if [ `uname` == "Darwin" ]; then
       git_credential='osxkeychain'
     fi
 
-    read -p "- What is your github author name? " git_authorname
-    read -p "- What is your github author email? " git_authoremail
+    if [ "$CIRCLE_CI" = "true" ]; then
+      git_authorname='test'
+      git_authoremail='test@test.com'
+    else
+      read -p "- What is your github author name? " git_authorname
+      read -p "- What is your github author email? " git_authoremail
+    fi
 
     sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" $DOTFILES/git/gitconfig.local.symlink.example > $DOTFILES/git/gitconfig.local.symlink
 
@@ -210,26 +215,30 @@ link_file () {
 
       else
 
-        user "File already exists: $dst ($(basename "$src")), what do you want to do?\n\
-        [s]kip, [S]kip all, [o]verwrite, [O]verwrite all, [b]ackup, [B]ackup all?"
-        read -n 1 action
+        if [ "$CIRCLE_CI" = "true" ]; then
+          skip=true;
+        else
+          user "File already exists: $dst ($(basename "$src")), what do you want to do?\n\
+          [s]kip, [S]kip all, [o]verwrite, [O]verwrite all, [b]ackup, [B]ackup all?"
+          read -n 1 action
 
-        case "$action" in
-          o )
-            overwrite=true;;
-          O )
-            overwrite_all=true;;
-          b )
-            backup=true;;
-          B )
-            backup_all=true;;
-          s )
-            skip=true;;
-          S )
-            skip_all=true;;
-          * )
-            ;;
-        esac
+          case "$action" in
+            o )
+              overwrite=true;;
+            O )
+              overwrite_all=true;;
+            b )
+              backup=true;;
+            B )
+              backup_all=true;;
+            s )
+              skip=true;;
+            S )
+              skip_all=true;;
+            * )
+              ;;
+          esac
+        fi
 
       fi
 
@@ -313,13 +322,15 @@ install_dotfiles() {
     message="You already have dotfiles installed, do you want to update? [Y/n] "
   fi
 
-  read -p "${message}" -n 1 y
-  echo ""
-  answer=`echo "${y}" | tr '[a-z]' '[A-Z]'`
+  if [ "$CIRCLE_CI" != "true" ]; then
+    read -p "${message}" -n 1 y
+    echo ""
+    answer=`echo "${y}" | tr '[a-z]' '[A-Z]'`
 
-  if [[ ${answer} != "Y" ]]
-  then
-    fail "Ok... maybe next time then."
+    if [[ ${answer} != "Y" ]]
+    then
+        fail "Ok... maybe next time then."
+    fi
   fi
 
   success "Here we go! 🚀"

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
 which zsh | sudo tee -a /etc/shells
-sudo chsh -s "$(which zsh)" "${USER}"
+
+if [[ -z "${USER}" ]]; then
+  sudo chsh -s "$(which zsh)"
+else
+  sudo chsh -s "$(which zsh)" "${USER}"
+fi


### PR DESCRIPTION
This PR adds a simple circleci workflow that runs dotfiles installation. The workflow fails if `dot` script exits with a code different than 0.

The workflow is only enabled for Linux distributions, due to the fact that to run this workflow on a macOS environment would require a CircleCI Performance Plan, which is overkill for the size of this open source project. 

Closes #34 .